### PR TITLE
Tablegen test refactor

### DIFF
--- a/dismantle-aarch64/tests/Main.hs
+++ b/dismantle-aarch64/tests/Main.hs
@@ -5,12 +5,13 @@ import Data.Char (isSpace)
 import qualified Data.List as L
 import qualified Test.Tasty as T
 import qualified Data.Text.Lazy as TL
-import qualified Dismantle.Testing.Regex as RE
 import Data.Word (Word64)
 import Data.Monoid ((<>))
 import qualified Text.PrettyPrint.HughesPJClass as PP
 
 import Dismantle.Testing
+import Dismantle.Testing.ParserTests (parserTests)
+import qualified Dismantle.Testing.Regex as RE
 
 import qualified Dismantle.ARM as ARM
 import qualified Dismantle.AArch64 as AArch64
@@ -38,7 +39,8 @@ aarch64 = ATC { testingISA = AArch64.isa
 main :: IO ()
 main = do
   tg <- binaryTestSuite aarch64 "tests/bin"
-  T.defaultMain tg
+  pt <- parserTests
+  T.defaultMain $ T.testGroup "dismantle-aarch64" [tg, pt]
 
 normalize :: TL.Text -> TL.Text
 normalize =

--- a/dismantle-arm/tests/Main.hs
+++ b/dismantle-arm/tests/Main.hs
@@ -5,12 +5,13 @@ import Data.Char (isSpace)
 import qualified Data.List as L
 import qualified Test.Tasty as T
 import qualified Data.Text.Lazy as TL
-import qualified Dismantle.Testing.Regex as RE
 import Data.Monoid ((<>))
 import qualified Text.PrettyPrint.HughesPJClass as PP
 import Data.Word (Word64)
 
 import Dismantle.Testing
+import Dismantle.Testing.ParserTests (parserTests)
+import qualified Dismantle.Testing.Regex as RE
 
 import qualified Dismantle.ARM as ARM
 import qualified Dismantle.ARM.ISA as ARM
@@ -129,7 +130,8 @@ arm = ATC { testingISA = ARM.isa
 main :: IO ()
 main = do
   tg <- binaryTestSuite arm "tests/bin"
-  T.defaultMain tg
+  pt <- parserTests
+  T.defaultMain $ T.testGroup "dismantle-arm" [tg, pt]
 
 normalize :: TL.Text -> TL.Text
 normalize =

--- a/dismantle-ppc/tests/Main.hs
+++ b/dismantle-ppc/tests/Main.hs
@@ -5,9 +5,10 @@ import Data.Char (isSpace)
 import qualified Data.List as L
 import qualified Test.Tasty as T
 import qualified Data.Text.Lazy as TL
-import qualified Dismantle.Testing.Regex as RE
 
 import Dismantle.Testing
+import Dismantle.Testing.ParserTests (parserTests)
+import qualified Dismantle.Testing.Regex as RE
 
 import qualified Dismantle.PPC as PPC
 import qualified Dismantle.PPC.ISA as PPC
@@ -28,7 +29,8 @@ ppc = ATC { testingISA = PPC.isa
 main :: IO ()
 main = do
   tg <- binaryTestSuite ppc "tests/bin"
-  T.defaultMain tg
+  pt <- parserTests
+  T.defaultMain $ T.testGroup "dismantle-ppc" [tg, pt]
 
 normalize :: TL.Text -> TL.Text
 normalize =

--- a/dismantle-tablegen/dismantle-tablegen.cabal
+++ b/dismantle-tablegen/dismantle-tablegen.cabal
@@ -29,6 +29,7 @@ library
                    Dismantle.Tablegen.Parser.Types
                    Dismantle.Testing
                    Dismantle.Testing.Parser
+                   Dismantle.Testing.ParserTests
                    Dismantle.Testing.Regex
                    Data.EnumF
                    Data.Int.Indexed
@@ -74,8 +75,7 @@ test-suite dismantle-tests
   ghc-options: -Wall -rtsopts
   hs-source-dirs: tests
   main-is: Main.hs
-  other-modules: Parser
-                 Operands
+  other-modules: Operands
                  Trie
   build-depends: dismantle-tablegen,
                  base,

--- a/dismantle-tablegen/src/Dismantle/Testing/ParserTests.hs
+++ b/dismantle-tablegen/src/Dismantle/Testing/ParserTests.hs
@@ -19,8 +19,9 @@ import qualified Dismantle.Tablegen.Parser.Types as D
 
 parserTests :: IO T.TestTree
 parserTests = do
-  tgenFiles <- findTgenFiles
-  return (T.testGroup "Parser" (map mkTest tgenFiles))
+  tgenFiles <- requireGlob "tgen files" "data/*.tgen"
+  overrideTgenFiles <- mapM canonicalizePath =<< G.namesMatching "data/override/*.tgen"
+  return $ T.testGroup "Parser" (map mkTest (tgenFiles <> overrideTgenFiles))
 
 requireGlob :: String -> String -> IO [FilePath]
 requireGlob ty pat = do
@@ -28,9 +29,6 @@ requireGlob ty pat = do
     when (null paths) $ do
         die $ "Error: could not find any " <> ty <> " matching " <> show pat
     return paths
-
-findTgenFiles :: IO [FilePath]
-findTgenFiles = requireGlob "tgen files" "data/*.tgen"
 
 mkTest :: FilePath -> T.TestTree
 mkTest p = T.testCase (takeFileName p) $ do

--- a/dismantle-tablegen/src/Dismantle/Testing/ParserTests.hs
+++ b/dismantle-tablegen/src/Dismantle/Testing/ParserTests.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE TupleSections #-}
-module Parser ( parserTests ) where
+module Dismantle.Testing.ParserTests (parserTests) where
 
-import Control.DeepSeq ( deepseq )
-import Control.Monad (when, forM)
+import Control.DeepSeq (deepseq)
+import Control.Monad (when)
 import Data.Monoid ((<>))
 import qualified Data.Text.IO as TS
 import qualified Data.Text.Lazy as TL
@@ -20,11 +20,7 @@ import qualified Dismantle.Tablegen.Parser.Types as D
 parserTests :: IO T.TestTree
 parserTests = do
   tgenFiles <- findTgenFiles
-  (T.testGroup "Parser") <$> mapM mkParserTestGroup tgenFiles
-
-mkParserTestGroup :: (String, [FilePath]) -> IO T.TestTree
-mkParserTestGroup (pkg, files) = do
-  return (T.testGroup pkg (map mkTest files))
+  return (T.testGroup "Parser" (map mkTest tgenFiles))
 
 requireGlob :: String -> String -> IO [FilePath]
 requireGlob ty pat = do
@@ -33,22 +29,8 @@ requireGlob ty pat = do
         die $ "Error: could not find any " <> ty <> " matching " <> show pat
     return paths
 
--- Find all .tgen files in this package and sibling packages, assuming
--- these tests are being run from a dismantle-tablegen build directory
--- where sibling dismantle-* projects are in the same directory as
--- dismantle-tablegen.
---
--- Returns the tablegen files it found, paired with the path to the
--- project that provides them.
---
--- Dies if no tablegen source files could be found.
-findTgenFiles :: IO [(FilePath, [FilePath])]
-findTgenFiles = do
-    projectPaths <- requireGlob "dismantle projects" "../dismantle-*"
-
-    forM projectPaths $ \project -> do
-        let tgenPattern = project <> "/data/*.tgen"
-        (project,) <$> requireGlob "tgen files" tgenPattern
+findTgenFiles :: IO [FilePath]
+findTgenFiles = requireGlob "tgen files" "data/*.tgen"
 
 mkTest :: FilePath -> T.TestTree
 mkTest p = T.testCase (takeFileName p) $ do

--- a/dismantle-tablegen/tests/Main.hs
+++ b/dismantle-tablegen/tests/Main.hs
@@ -2,8 +2,8 @@ module Main ( main ) where
 
 import qualified Test.Tasty as T
 
+import Dismantle.Testing.ParserTests ( parserTests )
 import Operands ( operandTests )
-import Parser ( parserTests )
 import Trie ( trieTests )
 
 main :: IO ()

--- a/dismantle-thumb/tests/Main.hs
+++ b/dismantle-thumb/tests/Main.hs
@@ -5,12 +5,13 @@ import Data.Char (isSpace)
 import qualified Data.List as L
 import qualified Test.Tasty as T
 import qualified Data.Text.Lazy as TL
-import qualified Dismantle.Testing.Regex as RE
 import Data.Monoid ((<>))
 import qualified Text.PrettyPrint.HughesPJClass as PP
 import Data.Word (Word64)
 
 import Dismantle.Testing
+import Dismantle.Testing.ParserTests (parserTests)
+import qualified Dismantle.Testing.Regex as RE
 
 import qualified Dismantle.Thumb as Thumb
 import qualified Dismantle.Thumb.ISA as Thumb
@@ -36,7 +37,8 @@ thumb = ATC { testingISA = Thumb.isa
 main :: IO ()
 main = do
   tg <- binaryTestSuite thumb "tests/bin"
-  T.defaultMain tg
+  pt <- parserTests
+  T.defaultMain $ T.testGroup "dismantle-thumb" [tg, pt]
 
 remove :: TL.Text -> TL.Text -> TL.Text
 remove needle s =


### PR DESCRIPTION
Rather than have dismantle-tablegen's tests go looking for .tgen files in other projects, move the parser testing functionality into the library, where it can be called by the tests of those projects which already depend on it.

- Simplify `parserTest` code to only look in local project's data/ directory
- Remove redundant AArch64.tgen file in dismantle-tablegen
- Also check data/override/*.tgen files
- Call `parserTest` in other dismantle projects' tests
- Lightly reorganize some imports while we're in there
