### PR TITLE
Fix an error due to orphan instances

### DIFF
--- a/dismantle-tablegen/dismantle-tablegen.cabal
+++ b/dismantle-tablegen/dismantle-tablegen.cabal
@@ -63,7 +63,7 @@ library
                        tasty-expected-failure,
                        megaparsec >= 7 && < 8,
                        regex-base >= 0.94,
-                       regex-tdfa,
+                       regex-tdfa >= 1.3.1 && < 1.4,
                        mtl >= 2 && < 3,
                        parameterized-utils >= 1 && < 2.1
   hs-source-dirs:      src

--- a/dismantle-tablegen/src/Dismantle/Testing/Regex.hs
+++ b/dismantle-tablegen/src/Dismantle/Testing/Regex.hs
@@ -16,7 +16,6 @@ module Dismantle.Testing.Regex
 import           Control.Monad.Fail
 import           Data.String
 import qualified Data.Text as DT
-import qualified Data.Text.Lazy as DLT
 import qualified Text.Regex.TDFA as RE
 
 
@@ -39,35 +38,3 @@ newtype EitherString a = EitherString { runEitherString :: Either String a }
 
 instance MonadFail EitherString where fail = EitherString . Left
 
--- --------------------------------------------------
-
-instance RE.RegexLike RE.Regex DT.Text where
-    matchOnce r = RE.matchOnce r . DT.unpack
-    matchAll r = RE.matchAll r . DT.unpack
-    matchCount r = RE.matchCount r . DT.unpack
-    matchTest r = RE.matchTest r . DT.unpack
-
-    matchAllText r s = let subres = RE.matchAllText r (DT.unpack s)
-                           reText (x, y) = (DT.pack x, y)
-                       in fmap (fmap reText) subres
-    matchOnceText r s = let subres = RE.matchOnceText r (DT.unpack s)
-                            reText (x, y) = (DT.pack x, y)
-                        in subres >>= \(a,b,c) ->
-                            return (DT.pack a, fmap reText b, DT.pack c)
-
-
--- --------------------------------------------------
-
-instance RE.RegexLike RE.Regex DLT.Text where
-    matchOnce r = RE.matchOnce r . DLT.unpack
-    matchAll r = RE.matchAll r . DLT.unpack
-    matchCount r = RE.matchCount r . DLT.unpack
-    matchTest r = RE.matchTest r . DLT.unpack
-
-    matchAllText r s = let subres = RE.matchAllText r $ DLT.unpack s
-                           reText (x, y) = (DLT.pack x, y)
-                       in fmap (fmap reText) subres
-    matchOnceText r s = let subres = RE.matchOnceText r $ DLT.unpack s
-                            reText (x, y) = (DLT.pack x, y)
-                        in subres >>= \(a,b,c) ->
-                            return (DLT.pack a, fmap reText b, DLT.pack c)


### PR DESCRIPTION
Add an explicit version dependency for regex-tdfa and delete the newly-orphan
instance.

Fixes #9.