### PR TITLE
Improve compilation times of disassemblers

### DIFF
--- a/dismantle-arm-xml/src/Dismantle/ARM/A32.hs
+++ b/dismantle-arm-xml/src/Dismantle/ARM/A32.hs
@@ -13,8 +13,10 @@
 -- valid Haskell, while the generated file Dismantle/PPC.th.hs will
 -- have only the top-level splices, and will be valid Haskell. The
 -- second file can be used when generating TAGS.
-{-# OPTIONS_GHC -ddump-splices -ddump-to-file -dth-dec-file -Wno-missing-signatures -fbinary-blob-threshold=50000 #-}
-
+{-# OPTIONS_GHC -ddump-splices -ddump-to-file -dth-dec-file -Wno-missing-signatures #-}
+#if MIN_VERSION_base(4, 14, 0)
+{-# OPTIONS_GHC -fbinary-blob-threshold=5000 #-}
+#endif
 module Dismantle.ARM.A32 (
   Instruction,
   AnnotatedInstruction,

--- a/dismantle-arm-xml/src/Dismantle/ARM/A32.hs
+++ b/dismantle-arm-xml/src/Dismantle/ARM/A32.hs
@@ -13,7 +13,7 @@
 -- valid Haskell, while the generated file Dismantle/PPC.th.hs will
 -- have only the top-level splices, and will be valid Haskell. The
 -- second file can be used when generating TAGS.
-{-# OPTIONS_GHC -ddump-splices -ddump-to-file -dth-dec-file -Wno-missing-signatures -O0 #-}
+{-# OPTIONS_GHC -ddump-splices -ddump-to-file -dth-dec-file -Wno-missing-signatures -fbinary-blob-threshold=50000 #-}
 
 module Dismantle.ARM.A32 (
   Instruction,

--- a/dismantle-arm-xml/src/Dismantle/ARM/T32.hs
+++ b/dismantle-arm-xml/src/Dismantle/ARM/T32.hs
@@ -13,7 +13,7 @@
 -- valid Haskell, while the generated file Dismantle/PPC.th.hs will
 -- have only the top-level splices, and will be valid Haskell. The
 -- second file can be used when generating TAGS.
-{-# OPTIONS_GHC -ddump-splices -ddump-to-file -dth-dec-file -Wno-missing-signatures -O0 #-}
+{-# OPTIONS_GHC -ddump-splices -ddump-to-file -dth-dec-file -Wno-missing-signatures -fbinary-blob-threshold=50000 #-}
 module Dismantle.ARM.T32 (
   Instruction,
   AnnotatedInstruction,

--- a/dismantle-arm-xml/src/Dismantle/ARM/T32.hs
+++ b/dismantle-arm-xml/src/Dismantle/ARM/T32.hs
@@ -13,7 +13,10 @@
 -- valid Haskell, while the generated file Dismantle/PPC.th.hs will
 -- have only the top-level splices, and will be valid Haskell. The
 -- second file can be used when generating TAGS.
-{-# OPTIONS_GHC -ddump-splices -ddump-to-file -dth-dec-file -Wno-missing-signatures -fbinary-blob-threshold=50000 #-}
+{-# OPTIONS_GHC -ddump-splices -ddump-to-file -dth-dec-file -Wno-missing-signatures #-}
+#if MIN_VERSION_base(4, 14, 0)
+{-# OPTIONS_GHC -fbinary-blob-threshold=5000 #-}
+#endif
 module Dismantle.ARM.T32 (
   Instruction,
   AnnotatedInstruction,

--- a/dismantle-ppc/src/Dismantle/PPC.hs
+++ b/dismantle-ppc/src/Dismantle/PPC.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
+{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity  -fbinary-blob-threshold=5000 #-}
 -- Dump TH splices to two files on disk. The generated file
 -- Dismantle/PPC.dump-splices will contain all splices, and not be
 -- valid Haskell, while the generated file Dismantle/PPC.th.hs will

--- a/dismantle-ppc/src/Dismantle/PPC.hs
+++ b/dismantle-ppc/src/Dismantle/PPC.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -6,13 +7,16 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity  -fbinary-blob-threshold=5000 #-}
+{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
 -- Dump TH splices to two files on disk. The generated file
 -- Dismantle/PPC.dump-splices will contain all splices, and not be
 -- valid Haskell, while the generated file Dismantle/PPC.th.hs will
 -- have only the top-level splices, and will be valid Haskell. The
 -- second file can be used when generating TAGS.
 {-# OPTIONS_GHC -ddump-splices -ddump-to-file -dth-dec-file #-}
+#if MIN_VERSION_base(4, 14, 0)
+{-# OPTIONS_GHC -fbinary-blob-threshold=5000 #-}
+#endif
 -- | Description: PPC opcodes generated from LLVM .tgen file
 --
 -- PPC opcodes generated from LLVM .tgen file.


### PR DESCRIPTION
This uses an ostensibly more efficient literal format in newer versions of
GHC (see the Template Haskell changes). The bigger factor, however, was forcing
the binary blob threshold lower (and possibly removing the -O0, which may have
been inhibiting that binary blob optimization).

The binary blob optimization[1] avoids putting large data literals into
generated assembly files and instead just puts them in external files that are
included via directive. This saves a huge amount of parsing time in the
assembler (shaving about 5 minutes off of the compilation time of
dismantle-arm-xml).

[1] https://gitlab.haskell.org/ghc/ghc/-/merge_requests/143/diffs