### PR TITLE
Allow building with GHC 9.0

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         arch: ['tablegen', 'arm', 'thumb', 'ppc', 'aarch64', 'arm-xml']
-        ghc: ['8.6.5', '8.8.3', '8.10.1']
+        ghc: ['8.6.5', '8.8.3', '8.10.1', '9.0.1']
         cabal: ['3.2.0.0']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         exclude:
@@ -26,10 +26,14 @@ jobs:
             ghc: 8.6.5
           - os: macOS-latest
             ghc: 8.8.3
+          - os: macOS-latest
+            ghc: 8.10.1
           - os: windows-latest
             ghc: 8.8.3
           - os: windows-latest
             ghc: 8.10.1
+          - os: windows-latest
+            ghc: 9.0.1
           # This configuration runs out of memory
           - os: windows-latest
             arch: aarch64
@@ -41,7 +45,7 @@ jobs:
       with:
         submodules: 'true'
 
-    - uses: actions/setup-haskell@v1
+    - uses: haskell/actions/setup@v1
       id: setup-haskell-cabal
       name: Setup Haskell
       with:

--- a/dismantle-tablegen/src/Dismantle/Tablegen/TH.hs
+++ b/dismantle-tablegen/src/Dismantle/Tablegen/TH.hs
@@ -455,7 +455,7 @@ There are only two steps for the TH, then:
 mkInstructionAliases :: Q [Dec]
 mkInstructionAliases =
   return [ TySynD (mkName "Instruction") [] ity
-         , TySynD (mkName "AnnotatedInstruction") [PlainTV annotVar] aty
+         , TySynD (mkName "AnnotatedInstruction") [plainTV annotVar] aty
          ]
   where
     annotVar = mkName "a"
@@ -481,8 +481,8 @@ mkOpcodeType isa = do
   where
     opVarName = mkName "o"
     shapeVarName = mkName "sh"
-    tyVars = [ KindedTV opVarName (ArrowT `AppT` ConT ''Symbol `AppT` StarT)
-             , KindedTV shapeVarName (ListT `AppT` ConT ''Symbol)
+    tyVars = [ kindedTV opVarName (ArrowT `AppT` ConT ''Symbol `AppT` StarT)
+             , kindedTV shapeVarName (ListT `AppT` ConT ''Symbol)
              ]
     cons = map mkOpcodeCon (isaInstructions isa)
 
@@ -624,7 +624,7 @@ mkReprType :: ISA -> Q [DecQ]
 mkReprType isa = do
   tpVarName <- newName "tp"
   let cons = map mkReprCon (isaOperandPayloadTypes isa)
-  return (dataDCompat (cxt []) operandReprName [PlainTV tpVarName] cons []
+  return (dataDCompat (cxt []) operandReprName [plainTV tpVarName] cons []
          : toStringSig
          : toStringFunc
          : map mkKnownReprInstance (isaOperandPayloadTypes isa)
@@ -723,7 +723,7 @@ mkOperandType isa desc = do
   -- Don't care about payloads here, just validation.
   mapM_ (lookupAndValidateOperand isa) (isaOperands desc)
   let cons = map mkOperandCon (isaOperandPayloadTypes isa)
-  return [ dataDCompat (cxt []) operandTypeName [KindedTV (mkName "tp") (ConT ''Symbol)] cons []
+  return [ dataDCompat (cxt []) operandTypeName [kindedTV (mkName "tp") (ConT ''Symbol)] cons []
          , standaloneDerivD (cxt []) [t| Show ($(conT operandTypeName) $(varT (mkName "tp"))) |]
          , mkOperandShowFInstance
          ]


### PR DESCRIPTION
This makes a couple of tweaks necessary to make `dismantle` and friends compile with GHC 9.0:

* The types of `PlainTV` and `KindedTV` changed in GHC 9.0, which prevents `dismantle-tablegen:Dismantle.Tablegen.TH` from building. To accommodate this change, I changed this module to use `plainTV` and `kindedTV` instead, which retain the old types prior to 9.0.
* A newer `parameterized-utils` submodule commit is now used which permits building with GHC 9.0.