### PR TITLE
Support building with GHC 9.2

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -18,16 +18,17 @@ jobs:
     strategy:
       matrix:
         arch: ['tablegen', 'arm', 'thumb', 'ppc', 'aarch64', 'arm-xml']
-        ghc: ['8.6.5', '8.8.4', '8.10.7', '9.0.2']
+        ghc: ['8.8.4', '8.10.7', '9.0.2', '9.2.2']
         cabal: ['3.6.2.0']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         exclude:
-          - os: macOS-latest
-            ghc: 8.6.5
+          # Only test macOS and Windows on the latest supported GHC versions
           - os: macOS-latest
             ghc: 8.8.4
           - os: macOS-latest
             ghc: 8.10.7
+          - os: macOS-latest
+            ghc: 9.0.2
           - os: windows-latest
             ghc: 8.8.4
           - os: windows-latest

--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -18,22 +18,22 @@ jobs:
     strategy:
       matrix:
         arch: ['tablegen', 'arm', 'thumb', 'ppc', 'aarch64', 'arm-xml']
-        ghc: ['8.6.5', '8.8.3', '8.10.1', '9.0.1']
-        cabal: ['3.2.0.0']
+        ghc: ['8.6.5', '8.8.4', '8.10.7', '9.0.2']
+        cabal: ['3.6.2.0']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         exclude:
           - os: macOS-latest
             ghc: 8.6.5
           - os: macOS-latest
-            ghc: 8.8.3
+            ghc: 8.8.4
           - os: macOS-latest
-            ghc: 8.10.1
+            ghc: 8.10.7
           - os: windows-latest
-            ghc: 8.8.3
+            ghc: 8.8.4
           - os: windows-latest
-            ghc: 8.10.1
+            ghc: 8.10.7
           - os: windows-latest
-            ghc: 9.0.1
+            ghc: 9.0.2
           # This configuration runs out of memory
           - os: windows-latest
             arch: aarch64

--- a/dismantle-arm-xml/src/Data/BitMask.hs
+++ b/dismantle-arm-xml/src/Data/BitMask.hs
@@ -35,7 +35,7 @@ a lookup will retrieve all elements with a key that matches the provided mask.
 
 module Data.BitMask
   (
-    -- * Generalized mask bits 
+    -- * Generalized mask bits
     MaskBit
   , SemiMaskBit(..)
   , HasBottomMaskBit(..)
@@ -55,7 +55,7 @@ module Data.BitMask
   , isQBit
   , bitToQuasi
   , bitAsQuasi
-  
+
   -- * Bitmasks as vectors of mask bits
   , BitMask
   , splitBitMask
@@ -66,7 +66,7 @@ module Data.BitMask
   , someBitMaskFromCons
   , prettyMask
   , prettySegmentedMask
-  
+
   -- * Bitsections as bitmasks with holes
   , BitSection
   , maskAsBitSection
@@ -78,9 +78,9 @@ module Data.BitMask
   , mkBitSectionHiBit
   , bitSectionFromList
   , bitSectionFromListHiBit
-   
+
   -- * Bitmask operations
-  , computePattern 
+  , computePattern
   , deriveMasks
 
   -- * Using bitmasks as lookup keys
@@ -88,7 +88,7 @@ module Data.BitMask
   , emptyMaskTrie
   , addToMaskTrie
   , lookupMaskTrie
-  
+
   -- re-exported vector functions
   , V.toList
   , V.fromList
@@ -632,7 +632,10 @@ addSectionToMask (BitSection mask) dest = do
   merged <- mergeBitMasksErr mask (fmap JustBit dest)
   -- The semantics of 'mergeBit' for 'WithBottom bit' guarantee that no 'BottomBit' bits are leftover after
   -- the merge.
-  return $ fmap (\(JustBit bit) -> bit) merged
+  return $ fmap (\wb -> case wb of
+                          JustBit bit -> bit
+                          BottomBit{} -> error $ "addSectionToMask: impossible")
+                merged
 
 prependErr :: ME.MonadError String m => String -> String -> m a
 prependErr msg err = ME.throwError $ msg ++ " " ++ err

--- a/dismantle-tablegen/src/Dismantle/Instruction.hs
+++ b/dismantle-tablegen/src/Dismantle/Instruction.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE PolyKinds #-}

--- a/dismantle-tablegen/src/Dismantle/Tablegen/TH/Capture.hs
+++ b/dismantle-tablegen/src/Dismantle/Tablegen/TH/Capture.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Dismantle.Tablegen.TH.Capture (
@@ -98,7 +99,7 @@ genMatchExpr operands operandListName body = do
         [] -> [p| SL.Nil |]
         ((opConStr, operandName) : rest) -> do
           let patRest = buildPattern rest
-          let p = ConP (mkName opConStr) [VarP operandName]
+          let p = conPCompat (mkName opConStr) [VarP operandName]
           [p| $(return p) SL.:< $(patRest) |]
 
 allocateMatchNames :: String -> [String] -> Q ([(String, Name)], Exp)
@@ -163,3 +164,10 @@ deconstructShape t =
       tlTypes <- deconstructShape tl
       return (hdType ++ tlTypes)
     _ -> fail ("Unexpected type structure: " ++ show t)
+
+conPCompat :: Name -> [Pat] -> Pat
+conPCompat n pats = ConP n
+#if MIN_VERSION_template_haskell(2,18,0)
+                           []
+#endif
+                           pats

--- a/dismantle-tablegen/src/Dismantle/Testing/ParserTests.hs
+++ b/dismantle-tablegen/src/Dismantle/Testing/ParserTests.hs
@@ -12,6 +12,7 @@ import qualified System.FilePath.Glob as G
 import System.Directory (canonicalizePath)
 import System.Exit (die)
 import System.FilePath (takeFileName)
+import qualified Text.Regex.TDFA as TDFA
 
 import qualified Dismantle.Tablegen as D
 import qualified Dismantle.Tablegen.Parser.Types as D
@@ -32,7 +33,7 @@ requireGlob ty pat = do
 mkTest :: FilePath -> T.TestTree
 mkTest p = T.testCase (takeFileName p) $ do
   t <- TS.readFile p
-  let (Right re) = RE.mkRegex "^def "
+  re <- TDFA.makeRegexM "^def "
   let expectedDefCount = RE.countMatches t re
   case D.parseTablegen p (TL.fromStrict t) of
     Left err ->


### PR DESCRIPTION
This contains a variety of changes needed to make the packages in the
`dismantle` repo compile with GHC 9.2:

* In GHC 9.2, enabling `UndecidableInstances` no longer implies enabling `FlexibleContexts` (see [here](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.2?version_id=7e2ce63ba042c1934654c4316dc02028d8d3dd31#undecidableinstances-no-longer-implies-flexiblecontexts-in-instance-declarations)). As a result, I had to enable `FlexibleContexts` in `dismantle-tablegen`'s `Dismantle.Instruction` module.
* In `template-haskell-2.18.*`, the type of `ConP` gained an additional field (see [here](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.2?version_id=7e2ce63ba042c1934654c4316dc02028d8d3dd31#template-haskell-218)). As a result, I needed to use some CPP in `dismantle-tablegen` to make it compile.
* The `parameterized-utils` submodule was bumped to bring in the changes from https://github.com/GaloisInc/parameterized-utils/pull/128, which allows it to build with GHC 9.2.

I also fixed various `-Wincomplete-uni-patterns` warnings that were uncovered by its inclusion in `-Wall` in GHC 9.2.