### PR TITLE
Split up large TH-generated modules

### DIFF
--- a/dismantle-aarch64/dismantle-aarch64.cabal
+++ b/dismantle-aarch64/dismantle-aarch64.cabal
@@ -16,6 +16,10 @@ library
                    Dismantle.AArch64.ISA
                    Dismantle.AArch64.Random
                    Dismantle.AArch64.Operands
+  other-modules:   Dismantle.AArch64.Opcodes
+                   Dismantle.AArch64.Disassembler
+                   Dismantle.AArch64.Assembler
+                   Dismantle.AArch64.PrettyPrint
   build-depends:       base >= 4.8 && < 5,
                        template-haskell,
                        parameterized-utils >= 1 && < 2.2,

--- a/dismantle-aarch64/src/Dismantle/AArch64.hs
+++ b/dismantle-aarch64/src/Dismantle/AArch64.hs
@@ -1,12 +1,3 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveLift #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
 module Dismantle.AArch64 (
   Instruction,
   AnnotatedInstruction,
@@ -21,19 +12,11 @@ module Dismantle.AArch64 (
   disassembleInstruction,
   assembleInstruction,
   ppInstruction
-  )where
+  ) where
 
-import Data.Parameterized.List ( List(..) )
-
-import Dismantle.ARM (mkPred)
-import Dismantle.AArch64.ISA ( isa )
-import Dismantle.Instruction
-import Dismantle.Tablegen.TH ( genISA, genInstances )
-
-$(genISA isa "data/AArch64.tgen" ["data/override"])
-$(return [])
-
--- We need a separate call to generate some instances, since the helper(s) that
--- create these instances use reify, which we can't call until we flush the TH
--- generation using the @$(return [])@ trick.
-$(genInstances)
+import Dismantle.AArch64.Assembler ( assembleInstruction )
+import Dismantle.AArch64.Disassembler ( disassembleInstruction )
+import Dismantle.AArch64.Opcodes ( Instruction, AnnotatedInstruction, List(..), Operand(..), OperandRepr(..), operandReprString, Opcode(..) )
+import Dismantle.AArch64.PrettyPrint ( ppInstruction )
+import Dismantle.ARM ( mkPred )
+import Dismantle.Instruction ( GenericInstruction(..), Annotated(..) )

--- a/dismantle-aarch64/src/Dismantle/AArch64/Assembler.hs
+++ b/dismantle-aarch64/src/Dismantle/AArch64/Assembler.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
+module Dismantle.AArch64.Assembler (
+  assembleInstruction
+  ) where
+
+import Dismantle.AArch64.ISA ( isa )
+import Dismantle.AArch64.Opcodes
+import Dismantle.Tablegen.TH ( genAssembler )
+
+$(genAssembler isa "data/AArch64.tgen" ["data/override"])

--- a/dismantle-aarch64/src/Dismantle/AArch64/Disassembler.hs
+++ b/dismantle-aarch64/src/Dismantle/AArch64/Disassembler.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
 module Dismantle.AArch64.Disassembler (
   disassembleInstruction
   ) where

--- a/dismantle-aarch64/src/Dismantle/AArch64/Disassembler.hs
+++ b/dismantle-aarch64/src/Dismantle/AArch64/Disassembler.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
+module Dismantle.AArch64.Disassembler (
+  disassembleInstruction
+  ) where
+
+import Dismantle.AArch64.ISA ( isa )
+import Dismantle.AArch64.Opcodes
+import Dismantle.Tablegen.TH ( genDisassembler )
+
+$(genDisassembler isa "data/AArch64.tgen" ["data/override"])

--- a/dismantle-aarch64/src/Dismantle/AArch64/Opcodes.hs
+++ b/dismantle-aarch64/src/Dismantle/AArch64/Opcodes.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
+module Dismantle.AArch64.Opcodes (
+  Instruction,
+  AnnotatedInstruction,
+  GenericInstruction(..),
+  List(..),
+  Annotated(..),
+  Operand(..),
+  OperandRepr(..),
+  operandReprString,
+  Opcode(..),
+  getInstructionTag
+  ) where
+
+import Data.Parameterized.List ( List(..) )
+
+import Dismantle.ARM ( mkPred )
+import Dismantle.AArch64.ISA ( isa )
+import Dismantle.Instruction
+import Dismantle.Tablegen.TH ( genOpcodeTypes, genInstances )
+
+$(genOpcodeTypes isa "data/AArch64.tgen" ["data/override"])
+$(return [])
+
+-- We need a separate call to generate some instances, since the helper(s) that
+-- create these instances use reify, which we can't call until we flush the TH
+-- generation using the @$(return [])@ trick.
+$(genInstances)

--- a/dismantle-aarch64/src/Dismantle/AArch64/PrettyPrint.hs
+++ b/dismantle-aarch64/src/Dismantle/AArch64/PrettyPrint.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
 module Dismantle.AArch64.PrettyPrint (
   ppInstruction
   ) where

--- a/dismantle-aarch64/src/Dismantle/AArch64/PrettyPrint.hs
+++ b/dismantle-aarch64/src/Dismantle/AArch64/PrettyPrint.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
+module Dismantle.AArch64.PrettyPrint (
+  ppInstruction
+  ) where
+
+import Dismantle.AArch64.ISA ( isa )
+import Dismantle.AArch64.Opcodes
+import Dismantle.Tablegen.TH ( genPrettyPrinter )
+
+$(genPrettyPrinter isa "data/AArch64.tgen" ["data/override"])

--- a/dismantle-arm/dismantle-arm.cabal
+++ b/dismantle-arm/dismantle-arm.cabal
@@ -16,6 +16,10 @@ library
                    Dismantle.ARM.ISA
                    Dismantle.ARM.Random
                    Dismantle.ARM.Operands
+  other-modules:   Dismantle.ARM.Opcodes
+                   Dismantle.ARM.Disassembler
+                   Dismantle.ARM.Assembler
+                   Dismantle.ARM.PrettyPrint
   build-depends:       base >= 4.8 && < 5,
                        template-haskell,
                        parameterized-utils >= 1 && < 2.2,

--- a/dismantle-arm/src/Dismantle/ARM.hs
+++ b/dismantle-arm/src/Dismantle/ARM.hs
@@ -1,12 +1,3 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveLift #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
 module Dismantle.ARM (
   Instruction,
   AnnotatedInstruction,
@@ -21,19 +12,11 @@ module Dismantle.ARM (
   disassembleInstruction,
   assembleInstruction,
   ppInstruction
-  )where
+  ) where
 
-import Data.Parameterized.List ( List(..) )
-
-import Dismantle.ARM.ISA ( isa )
-import Dismantle.Instruction
-import Dismantle.Tablegen.TH ( genISA, genInstances )
-import Dismantle.ARM.Operands (mkPred)
-
-$(genISA isa "data/ARM.tgen" [])
-$(return [])
-
--- We need a separate call to generate some instances, since the helper(s) that
--- create these instances use reify, which we can't call until we flush the TH
--- generation using the @$(return [])@ trick.
-$(genInstances)
+import Dismantle.Instruction ( GenericInstruction(..), Annotated(..) )
+import Dismantle.ARM.Assembler ( assembleInstruction )
+import Dismantle.ARM.Disassembler ( disassembleInstruction )
+import Dismantle.ARM.Opcodes ( Instruction, AnnotatedInstruction, List(..), Operand(..), OperandRepr(..), operandReprString, Opcode(..) )
+import Dismantle.ARM.Operands ( mkPred )
+import Dismantle.ARM.PrettyPrint ( ppInstruction )

--- a/dismantle-arm/src/Dismantle/ARM/Assembler.hs
+++ b/dismantle-arm/src/Dismantle/ARM/Assembler.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
+module Dismantle.ARM.Assembler (
+  assembleInstruction
+  ) where
+
+import Dismantle.ARM.ISA ( isa )
+import Dismantle.ARM.Opcodes
+import Dismantle.ARM.Operands
+import Dismantle.Tablegen.TH ( genAssembler )
+
+$(genAssembler isa "data/ARM.tgen" [])

--- a/dismantle-arm/src/Dismantle/ARM/Disassembler.hs
+++ b/dismantle-arm/src/Dismantle/ARM/Disassembler.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
+module Dismantle.ARM.Disassembler (
+  disassembleInstruction
+  ) where
+
+import Dismantle.ARM.ISA ( isa )
+import Dismantle.ARM.Opcodes
+import Dismantle.ARM.Operands
+import Dismantle.Tablegen.TH ( genDisassembler )
+
+$(genDisassembler isa "data/ARM.tgen" [])

--- a/dismantle-arm/src/Dismantle/ARM/Disassembler.hs
+++ b/dismantle-arm/src/Dismantle/ARM/Disassembler.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
 module Dismantle.ARM.Disassembler (
   disassembleInstruction
   ) where

--- a/dismantle-arm/src/Dismantle/ARM/Opcodes.hs
+++ b/dismantle-arm/src/Dismantle/ARM/Opcodes.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
+module Dismantle.ARM.Opcodes (
+  Instruction,
+  AnnotatedInstruction,
+  GenericInstruction(..),
+  List(..),
+  Annotated(..),
+  Operand(..),
+  OperandRepr(..),
+  operandReprString,
+  Opcode(..),
+  getInstructionTag
+  ) where
+
+import Data.Parameterized.List ( List(..) )
+
+import Dismantle.ARM.ISA ( isa )
+import Dismantle.Instruction
+import Dismantle.Tablegen.TH ( genOpcodeTypes, genInstances )
+
+$(genOpcodeTypes isa "data/ARM.tgen" [])
+$(return [])
+
+-- We need a separate call to generate some instances, since the helper(s) that
+-- create these instances use reify, which we can't call until we flush the TH
+-- generation using the @$(return [])@ trick.
+$(genInstances)

--- a/dismantle-arm/src/Dismantle/ARM/PrettyPrint.hs
+++ b/dismantle-arm/src/Dismantle/ARM/PrettyPrint.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
+module Dismantle.ARM.PrettyPrint (
+  ppInstruction
+  ) where
+
+import Dismantle.ARM.ISA ( isa )
+import Dismantle.ARM.Opcodes
+import Dismantle.ARM.Operands
+import Dismantle.Tablegen.TH ( genPrettyPrinter )
+
+$(genPrettyPrinter isa "data/ARM.tgen" [])

--- a/dismantle-arm/src/Dismantle/ARM/PrettyPrint.hs
+++ b/dismantle-arm/src/Dismantle/ARM/PrettyPrint.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
 module Dismantle.ARM.PrettyPrint (
   ppInstruction
   ) where

--- a/dismantle-ppc/dismantle-ppc.cabal
+++ b/dismantle-ppc/dismantle-ppc.cabal
@@ -15,7 +15,11 @@ library
   exposed-modules: Dismantle.PPC
                    Dismantle.PPC.ISA
                    Dismantle.PPC.Random
-  other-modules: Dismantle.PPC.Operands
+  other-modules:   Dismantle.PPC.Opcodes
+                   Dismantle.PPC.Disassembler
+                   Dismantle.PPC.Assembler
+                   Dismantle.PPC.PrettyPrint
+                   Dismantle.PPC.Operands
   build-depends:       base >= 4.8 && < 5,
                        template-haskell,
                        parameterized-utils >= 1 && < 2.2,

--- a/dismantle-ppc/src/Dismantle/PPC.hs
+++ b/dismantle-ppc/src/Dismantle/PPC.hs
@@ -1,22 +1,3 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveLift #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
--- Dump TH splices to two files on disk. The generated file
--- Dismantle/PPC.dump-splices will contain all splices, and not be
--- valid Haskell, while the generated file Dismantle/PPC.th.hs will
--- have only the top-level splices, and will be valid Haskell. The
--- second file can be used when generating TAGS.
-{-# OPTIONS_GHC -ddump-splices -ddump-to-file -dth-dec-file #-}
-#if MIN_VERSION_base(4, 14, 0)
-{-# OPTIONS_GHC -fbinary-blob-threshold=5000 #-}
-#endif
 -- | Description: PPC opcodes generated from LLVM .tgen file
 --
 -- PPC opcodes generated from LLVM .tgen file.
@@ -100,19 +81,11 @@ module Dismantle.PPC (
   disassembleInstruction,
   assembleInstruction,
   ppInstruction
-  )where
+  ) where
 
-import Data.Parameterized.List ( List(..) )
-
-import Dismantle.Instruction
+import Dismantle.Instruction ( GenericInstruction(..), Annotated(..) )
+import Dismantle.PPC.Assembler ( assembleInstruction )
+import Dismantle.PPC.Disassembler ( disassembleInstruction )
+import Dismantle.PPC.Opcodes ( Instruction, AnnotatedInstruction, List(..), Operand(..), OperandRepr(..), operandReprString, Opcode(..) )
 import Dismantle.PPC.Operands
-import Dismantle.PPC.ISA ( isa )
-import Dismantle.Tablegen.TH ( genISA, genInstances )
-
-$(genISA isa "data/PPC.tgen" ["data/override"])
-$(return [])
-
--- We need a separate call to generate some instances, since the helper(s) that
--- create these instances use reify, which we can't call until we flush the TH
--- generation using the @$(return [])@ trick.
-$(genInstances)
+import Dismantle.PPC.PrettyPrint ( ppInstruction )

--- a/dismantle-ppc/src/Dismantle/PPC/Assembler.hs
+++ b/dismantle-ppc/src/Dismantle/PPC/Assembler.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
-{-# OPTIONS_GHC -ddump-splices -ddump-to-file -dth-dec-file #-}
 #if MIN_VERSION_base(4, 14, 0)
 {-# OPTIONS_GHC -fbinary-blob-threshold=5000 #-}
 #endif

--- a/dismantle-ppc/src/Dismantle/PPC/Assembler.hs
+++ b/dismantle-ppc/src/Dismantle/PPC/Assembler.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
+{-# OPTIONS_GHC -ddump-splices -ddump-to-file -dth-dec-file #-}
+#if MIN_VERSION_base(4, 14, 0)
+{-# OPTIONS_GHC -fbinary-blob-threshold=5000 #-}
+#endif
+module Dismantle.PPC.Assembler (
+  assembleInstruction
+  ) where
+
+import Dismantle.PPC.ISA ( isa )
+import Dismantle.PPC.Opcodes
+import Dismantle.PPC.Operands
+import Dismantle.Tablegen.TH ( genAssembler )
+
+$(genAssembler isa "data/PPC.tgen" ["data/override"])

--- a/dismantle-ppc/src/Dismantle/PPC/Disassembler.hs
+++ b/dismantle-ppc/src/Dismantle/PPC/Disassembler.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
+{-# OPTIONS_GHC -ddump-splices -ddump-to-file -dth-dec-file #-}
+#if MIN_VERSION_base(4, 14, 0)
+{-# OPTIONS_GHC -fbinary-blob-threshold=5000 #-}
+#endif
+module Dismantle.PPC.Disassembler (
+  disassembleInstruction
+  ) where
+
+import Dismantle.PPC.ISA ( isa )
+import Dismantle.PPC.Opcodes
+import Dismantle.Tablegen.TH ( genDisassembler )
+
+$(genDisassembler isa "data/PPC.tgen" ["data/override"])

--- a/dismantle-ppc/src/Dismantle/PPC/Disassembler.hs
+++ b/dismantle-ppc/src/Dismantle/PPC/Disassembler.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
 {-# OPTIONS_GHC -ddump-splices -ddump-to-file -dth-dec-file #-}
 #if MIN_VERSION_base(4, 14, 0)
 {-# OPTIONS_GHC -fbinary-blob-threshold=5000 #-}

--- a/dismantle-ppc/src/Dismantle/PPC/Disassembler.hs
+++ b/dismantle-ppc/src/Dismantle/PPC/Disassembler.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -ddump-splices -ddump-to-file -dth-dec-file #-}
 #if MIN_VERSION_base(4, 14, 0)
 {-# OPTIONS_GHC -fbinary-blob-threshold=5000 #-}
 #endif

--- a/dismantle-ppc/src/Dismantle/PPC/Opcodes.hs
+++ b/dismantle-ppc/src/Dismantle/PPC/Opcodes.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
-{-# OPTIONS_GHC -ddump-splices -ddump-to-file -dth-dec-file #-}
 #if MIN_VERSION_base(4, 14, 0)
 {-# OPTIONS_GHC -fbinary-blob-threshold=5000 #-}
 #endif

--- a/dismantle-ppc/src/Dismantle/PPC/Opcodes.hs
+++ b/dismantle-ppc/src/Dismantle/PPC/Opcodes.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
+{-# OPTIONS_GHC -ddump-splices -ddump-to-file -dth-dec-file #-}
+#if MIN_VERSION_base(4, 14, 0)
+{-# OPTIONS_GHC -fbinary-blob-threshold=5000 #-}
+#endif
+module Dismantle.PPC.Opcodes (
+  Instruction,
+  AnnotatedInstruction,
+  GenericInstruction(..),
+  List(..),
+  Annotated(..),
+  Operand(..),
+  OperandRepr(..),
+  operandReprString,
+  Opcode(..),
+  getInstructionTag
+  ) where
+
+import Data.Parameterized.List ( List(..) )
+
+import Dismantle.Instruction
+import Dismantle.PPC.Operands
+import Dismantle.PPC.ISA ( isa )
+import Dismantle.Tablegen.TH ( genOpcodeTypes, genInstances )
+
+$(genOpcodeTypes isa "data/PPC.tgen" ["data/override"])
+$(return [])
+
+-- We need a separate call to generate some instances, since the helper(s) that
+-- create these instances use reify, which we can't call until we flush the TH
+-- generation using the @$(return [])@ trick.
+$(genInstances)

--- a/dismantle-ppc/src/Dismantle/PPC/PrettyPrint.hs
+++ b/dismantle-ppc/src/Dismantle/PPC/PrettyPrint.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
+{-# OPTIONS_GHC -ddump-splices -ddump-to-file -dth-dec-file #-}
+#if MIN_VERSION_base(4, 14, 0)
+{-# OPTIONS_GHC -fbinary-blob-threshold=5000 #-}
+#endif
+module Dismantle.PPC.PrettyPrint (
+  ppInstruction
+  ) where
+
+import Dismantle.PPC.ISA ( isa )
+import Dismantle.PPC.Opcodes
+import Dismantle.PPC.Operands
+import Dismantle.Tablegen.TH ( genPrettyPrinter )
+
+$(genPrettyPrinter isa "data/PPC.tgen" ["data/override"])

--- a/dismantle-ppc/src/Dismantle/PPC/PrettyPrint.hs
+++ b/dismantle-ppc/src/Dismantle/PPC/PrettyPrint.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
 {-# OPTIONS_GHC -ddump-splices -ddump-to-file -dth-dec-file #-}
 #if MIN_VERSION_base(4, 14, 0)
 {-# OPTIONS_GHC -fbinary-blob-threshold=5000 #-}

--- a/dismantle-ppc/src/Dismantle/PPC/PrettyPrint.hs
+++ b/dismantle-ppc/src/Dismantle/PPC/PrettyPrint.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -ddump-splices -ddump-to-file -dth-dec-file #-}
 #if MIN_VERSION_base(4, 14, 0)
 {-# OPTIONS_GHC -fbinary-blob-threshold=5000 #-}
 #endif

--- a/dismantle-tablegen/src/Dismantle/Tablegen/TH.hs
+++ b/dismantle-tablegen/src/Dismantle/Tablegen/TH.hs
@@ -105,7 +105,7 @@ loadISA :: ISA
         -- used to override entries in the base tablegen data.
         -> Q ISADescriptor
 loadISA isa path overridePaths = do
-  initialRecs <- runIO $ loadTablegen path
+  initialRecs <- loadTablegen path
   overrides <- loadOverrides overridePaths
   return $ filterISA isa $ applyOverrides overrides initialRecs
 
@@ -133,7 +133,6 @@ genISADesc isa desc paths mtrie = do
 genOpcodeTypes :: ISA -> FilePath -> [FilePath] -> DecsQ
 genOpcodeTypes isa path overridePaths = do
   desc <- loadISA isa path overridePaths
-  qAddDependentFile path
   mkOpcodeTypeDecls isa desc
 
 -- | Generate only the disassembler (@disassembleInstruction@).
@@ -142,7 +141,6 @@ genOpcodeTypes isa path overridePaths = do
 genDisassembler :: ISA -> FilePath -> [FilePath] -> DecsQ
 genDisassembler isa path overridePaths = do
   desc <- loadISA isa path overridePaths
-  qAddDependentFile path
   mkParser isa desc Nothing
 
 -- | Generate only the assembler (@assembleInstruction@).
@@ -150,7 +148,6 @@ genDisassembler isa path overridePaths = do
 genAssembler :: ISA -> FilePath -> [FilePath] -> DecsQ
 genAssembler isa path overridePaths = do
   desc <- loadISA isa path overridePaths
-  qAddDependentFile path
   mkAssembler isa desc
 
 -- | Generate only the pretty-printer (@ppInstruction@).
@@ -158,7 +155,6 @@ genAssembler isa path overridePaths = do
 genPrettyPrinter :: ISA -> FilePath -> [FilePath] -> DecsQ
 genPrettyPrinter isa path overridePaths = do
   desc <- loadISA isa path overridePaths
-  qAddDependentFile path
   mkPrettyPrinter desc
 
 -- | Shared helper: all declarations that belong in the Opcodes module.
@@ -186,9 +182,10 @@ mkOpcodeTypeDecls isa desc = do
   return $ concat allDecls
 
 
-loadTablegen :: FilePath -> IO Records
+loadTablegen :: FilePath -> Q Records
 loadTablegen path = do
-  txt <- TL.readFile path
+  txt <- runIO $ TL.readFile path
+  qAddDependentFile path
   case parseTablegen path txt of
     Left err -> fail err
     Right defs -> return defs
@@ -222,8 +219,7 @@ loadOverridesFromDir path = do
 
             let go [] = return emptyRecords
                 go (f:rest) = do
-                    overrides <- runIO $ loadTablegen f
-                    qAddDependentFile f
+                    overrides <- loadTablegen f
                     desc <- go rest
                     return $ applyOverrides overrides desc
 

--- a/dismantle-tablegen/src/Dismantle/Tablegen/TH.hs
+++ b/dismantle-tablegen/src/Dismantle/Tablegen/TH.hs
@@ -10,7 +10,6 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ViewPatterns #-}
 module Dismantle.Tablegen.TH (
-  genISA,
   genISADesc,
   genOpcodeTypes,
   genDisassembler,
@@ -109,11 +108,6 @@ loadISA isa path overridePaths = do
   initialRecs <- runIO $ loadTablegen path
   overrides <- loadOverrides overridePaths
   return $ filterISA isa $ applyOverrides overrides initialRecs
-
-genISA :: ISA -> FilePath -> [FilePath] -> DecsQ
-genISA isa path overridePaths = do
-  desc <- loadISA isa path overridePaths
-  genISADesc isa desc [path] Nothing
 
 -- | This function creates all of the definitions for an ISA disassembler/assembler
 --

--- a/dismantle-tablegen/src/Dismantle/Tablegen/TH.hs
+++ b/dismantle-tablegen/src/Dismantle/Tablegen/TH.hs
@@ -12,6 +12,10 @@
 module Dismantle.Tablegen.TH (
   genISA,
   genISADesc,
+  genOpcodeTypes,
+  genDisassembler,
+  genAssembler,
+  genPrettyPrinter,
   genInstances,
   genISARandomHelpers,
   -- * More internal helpers
@@ -122,24 +126,70 @@ genISADesc isa desc paths mtrie = do
   case isaErrors desc of
     [] -> return ()
     errs -> reportWarning ("Unhandled instruction definitions for ISA: " ++ show (length errs))
+  opcodeDecls <- mkOpcodeTypeDecls isa desc
+  ppDef <- mkPrettyPrinter desc
+  parserDef <- mkParser isa desc mtrie
+  asmDef <- mkAssembler isa desc
+  return $ concat [opcodeDecls, ppDef, parserDef, asmDef]
 
+-- | Generate only the opcode/operand types, repr types, instruction aliases,
+-- and getInstructionTag helper. Intended for use in a dedicated @Opcodes@
+-- sub-module; the disassembler, assembler, and pretty-printer modules can then
+-- import that sub-module and each be compiled in parallel.
+genOpcodeTypes :: ISA -> FilePath -> [FilePath] -> DecsQ
+genOpcodeTypes isa path overridePaths = do
+  desc <- loadISA isa path overridePaths
+  qAddDependentFile path
+  mkOpcodeTypeDecls isa desc
+
+-- | Generate only the disassembler (@disassembleInstruction@).
+-- The opcode/operand types must already be in scope (i.e. import the
+-- corresponding @Opcodes@ module before this splice).
+genDisassembler :: ISA -> FilePath -> [FilePath] -> DecsQ
+genDisassembler isa path overridePaths = do
+  desc <- loadISA isa path overridePaths
+  qAddDependentFile path
+  mkParser isa desc Nothing
+
+-- | Generate only the assembler (@assembleInstruction@).
+-- The opcode/operand types must already be in scope.
+genAssembler :: ISA -> FilePath -> [FilePath] -> DecsQ
+genAssembler isa path overridePaths = do
+  desc <- loadISA isa path overridePaths
+  qAddDependentFile path
+  mkAssembler isa desc
+
+-- | Generate only the pretty-printer (@ppInstruction@).
+-- The opcode/operand types must already be in scope.
+genPrettyPrinter :: ISA -> FilePath -> [FilePath] -> DecsQ
+genPrettyPrinter isa path overridePaths = do
+  desc <- loadISA isa path overridePaths
+  qAddDependentFile path
+  mkPrettyPrinter desc
+
+-- | Shared helper: all declarations that belong in the Opcodes module.
+mkOpcodeTypeDecls :: ISA -> ISADescriptor -> Q [Dec]
+mkOpcodeTypeDecls isa desc = do
   operandType <- mkOperandType isa desc >>= sequence
   opcodeType <- mkOpcodeType desc >>= sequence
   instrTypes <- mkInstructionAliases
   reprTypeDecls <- mkReprType isa >>= sequence
   setWrapperType <- [d| newtype NESetWrapper o p = NESetWrapper { unwrapNESet :: (NES.Set ($(conT $ mkName "Opcode") o p)) } |]
-  ppDef <- mkPrettyPrinter desc
-  parserDef <- mkParser isa desc mtrie
-  asmDef <- mkAssembler isa desc
-  return $ concat [ operandType
-                  , opcodeType
-                  , reprTypeDecls
-                  , setWrapperType
-                  , instrTypes
-                  , ppDef
-                  , parserDef
-                  , asmDef
-                  ]
+  insTagTy <- [t| $(conT (mkName "Instruction")) -> Some $(conT (mkName "Opcode") `appT` (conT (mkName "Operand"))) |]
+  tagExpr <- [e| Some $(varE $ mkName "t") |]
+  let insTagDec =
+        [ SigD insnTagName insTagTy
+        , FunD insnTagName [Clause [conPCompat 'Instruction [VarP (mkName "t"), WildP]] (NormalB tagExpr) []]
+        ]
+  let allDecls =
+        [ operandType
+        , opcodeType
+        , reprTypeDecls
+        , setWrapperType
+        , instrTypes
+        , insTagDec
+        ]
+  return $ concat allDecls
 
 
 loadTablegen :: FilePath -> IO Records
@@ -370,7 +420,6 @@ mkAssembler :: ISA -> ISADescriptor -> Q [Dec]
 mkAssembler isa desc = do
   insnName <- newName "insn"
   unparserTy <- [t| $(conT (mkName "Instruction")) -> LBS.ByteString |]
-  insTagTy <- [t| $(conT (mkName "Instruction")) -> Some $(conT (mkName "Opcode") `appT` (conT (mkName "Operand"))) |]
   pairsTy <- [t| M.Map (Some ($(conT (mkName "Opcode")) $(conT (mkName "Operand")))) ($(conT (mkName "Instruction")) -> LBS.ByteString) |]
   cases <- mapM (mkAsmCase isa) (isaInstructions desc)
 
@@ -383,7 +432,6 @@ mkAssembler isa desc = do
 
   pairsBody <- ListE <$> mapM mkTuple pairs
   mapExpr <- [e| M.fromList $(return pairsBody) |]
-  tagExpr <- [e| Some $(varE $ mkName "t") |]
 
   -- maybe (error "") ($ i) lookup (getOpcode isnName) (Data.Map.fromList pairs)
   body <- [e| maybe (error "BUG: Unhandled instruction in assembler")
@@ -393,14 +441,9 @@ mkAssembler isa desc = do
   let pairsExpr = [ SigD pairsExprName pairsTy
                   , ValD (VarP pairsExprName) (NormalB mapExpr) []
                   ]
-      insTagExpr = [ SigD insnTagName insTagTy
-                   , FunD insnTagName [Clause [conPCompat 'Instruction [VarP (mkName "t"), WildP]] (NormalB tagExpr) []]
-                   ]
-
 
   return $ decls <>
            pairsExpr <>
-           insTagExpr <>
            [ SigD unparserName unparserTy
            , FunD unparserName [Clause [VarP insnName] (NormalB body) []]
            ]

--- a/dismantle-thumb/dismantle-thumb.cabal
+++ b/dismantle-thumb/dismantle-thumb.cabal
@@ -16,6 +16,10 @@ library
                    Dismantle.Thumb.ISA
                    Dismantle.Thumb.Operands
                    Dismantle.Thumb.Random
+  other-modules:   Dismantle.Thumb.Opcodes
+                   Dismantle.Thumb.Disassembler
+                   Dismantle.Thumb.Assembler
+                   Dismantle.Thumb.PrettyPrint
   build-depends:       base >= 4.8 && < 5,
                        template-haskell,
                        parameterized-utils >= 1 && < 2.2,

--- a/dismantle-thumb/src/Dismantle/Thumb.hs
+++ b/dismantle-thumb/src/Dismantle/Thumb.hs
@@ -1,12 +1,3 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveLift #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
 module Dismantle.Thumb (
   Instruction,
   AnnotatedInstruction,
@@ -21,19 +12,11 @@ module Dismantle.Thumb (
   disassembleInstruction,
   assembleInstruction,
   ppInstruction
-  )where
+  ) where
 
-import Data.Parameterized.List ( List(..) )
-
-import Dismantle.Thumb.ISA ( isa )
-import Dismantle.Instruction
-import Dismantle.Tablegen.TH ( genISA, genInstances )
-import Dismantle.Thumb.Operands (mkPred)
-
-$(genISA isa "data/ARM.tgen" ["data/overrides"])
-$(return [])
-
--- We need a separate call to generate some instances, since the helper(s) that
--- create these instances use reify, which we can't call until we flush the TH
--- generation using the @$(return [])@ trick.
-$(genInstances)
+import Dismantle.Instruction ( GenericInstruction(..), Annotated(..) )
+import Dismantle.Thumb.Assembler ( assembleInstruction )
+import Dismantle.Thumb.Disassembler ( disassembleInstruction )
+import Dismantle.Thumb.Opcodes ( Instruction, AnnotatedInstruction, List(..), Operand(..), OperandRepr(..), operandReprString, Opcode(..) )
+import Dismantle.Thumb.Operands ( mkPred )
+import Dismantle.Thumb.PrettyPrint ( ppInstruction )

--- a/dismantle-thumb/src/Dismantle/Thumb/Assembler.hs
+++ b/dismantle-thumb/src/Dismantle/Thumb/Assembler.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
+module Dismantle.Thumb.Assembler (
+  assembleInstruction
+  ) where
+
+import Dismantle.Thumb.ISA ( isa )
+import Dismantle.Thumb.Opcodes
+import Dismantle.ARM.Operands
+import Dismantle.Thumb.Operands hiding ( Opcode )
+import Dismantle.Tablegen.TH ( genAssembler )
+
+$(genAssembler isa "data/ARM.tgen" ["data/overrides"])

--- a/dismantle-thumb/src/Dismantle/Thumb/Disassembler.hs
+++ b/dismantle-thumb/src/Dismantle/Thumb/Disassembler.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
+module Dismantle.Thumb.Disassembler (
+  disassembleInstruction
+  ) where
+
+import Dismantle.Thumb.ISA ( isa )
+import Dismantle.Thumb.Opcodes
+import Dismantle.ARM.Operands
+import Dismantle.Thumb.Operands hiding ( Opcode )
+import Dismantle.Tablegen.TH ( genDisassembler )
+
+$(genDisassembler isa "data/ARM.tgen" ["data/overrides"])

--- a/dismantle-thumb/src/Dismantle/Thumb/Disassembler.hs
+++ b/dismantle-thumb/src/Dismantle/Thumb/Disassembler.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
 module Dismantle.Thumb.Disassembler (
   disassembleInstruction
   ) where

--- a/dismantle-thumb/src/Dismantle/Thumb/Opcodes.hs
+++ b/dismantle-thumb/src/Dismantle/Thumb/Opcodes.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
+module Dismantle.Thumb.Opcodes (
+  Instruction,
+  AnnotatedInstruction,
+  GenericInstruction(..),
+  List(..),
+  Annotated(..),
+  Operand(..),
+  OperandRepr(..),
+  operandReprString,
+  Opcode(..),
+  getInstructionTag
+  ) where
+
+import Data.Parameterized.List ( List(..) )
+
+import Dismantle.ARM ( mkPred )
+import Dismantle.Thumb.ISA ( isa )
+import Dismantle.Instruction
+import Dismantle.Tablegen.TH ( genOpcodeTypes, genInstances )
+
+$(genOpcodeTypes isa "data/ARM.tgen" ["data/overrides"])
+$(return [])
+
+-- We need a separate call to generate some instances, since the helper(s) that
+-- create these instances use reify, which we can't call until we flush the TH
+-- generation using the @$(return [])@ trick.
+$(genInstances)

--- a/dismantle-thumb/src/Dismantle/Thumb/PrettyPrint.hs
+++ b/dismantle-thumb/src/Dismantle/Thumb/PrettyPrint.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
+module Dismantle.Thumb.PrettyPrint (
+  ppInstruction
+  ) where
+
+import Dismantle.Thumb.ISA ( isa )
+import Dismantle.Thumb.Opcodes
+import Dismantle.ARM.Operands
+import Dismantle.Thumb.Operands hiding ( Opcode )
+import Dismantle.Tablegen.TH ( genPrettyPrinter )
+
+$(genPrettyPrinter isa "data/ARM.tgen" ["data/overrides"])

--- a/dismantle-thumb/src/Dismantle/Thumb/PrettyPrint.hs
+++ b/dismantle-thumb/src/Dismantle/Thumb/PrettyPrint.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -fno-spec-constr -fno-specialise -fmax-simplifier-iterations=1 -fno-call-arity #-}
 module Dismantle.Thumb.PrettyPrint (
   ppInstruction
   ) where


### PR DESCRIPTION
At `-j14`, this speeds up aarch64 from 223.1s to 168.3s and peak memory from 1867MB to 1075MB. Towards #54.